### PR TITLE
Updated input-related structs, added some new fields

### DIFF
--- a/src/InputManager.hpp
+++ b/src/InputManager.hpp
@@ -18,16 +18,46 @@ namespace SokuLib
 		int changeCard;
 		int spellcard;
 	};
+	
+	struct CharacterSelectKeys {
+		bool up: 1;
+		bool down: 1;
+		bool left: 1;
+		bool right: 1;
+		bool Z: 1;
+		bool X: 1;
+		bool C: 1;
+		bool A: 1;
+		bool dash: 1;
+		bool Q: 1;
+		unsigned char padding: 6;
+	};
+
+	struct BattleKeys {
+		bool up: 1;
+		bool down: 1;
+		bool left: 1;
+		bool right: 1;
+		bool A: 1;
+		bool B: 1;
+		bool C: 1;
+		bool dash: 1;
+		bool AandB: 1;
+		bool BandC: 1;
+		bool pause: 1;
+		bool select: 1;
+		unsigned char padding: 4;
+	};
 
 	//KEYMAPMGR
 	//CInputManagerCluster
 	struct KeymapManager {
-		char unknown[0x4];
+		void *unknown;
 		// isPlayer is -1 when using keyboard, 0 when using first gamepad, 1 when using second gamepad.
 		char isPlayer;
 
-		// for keyboard, these are DirectX key codes (see dinput.h)
-		// for controller, these are DIJOYPOD::rgbButton indices; for the directions they're -1.
+		// for keyboard, these are DirectX key codes (see dinput.h / DIKEY.md)
+		// for controller, these are DIJOYPAD::rgbButton indices (and -1 for up/down/left/right).
 		int bindingUp;
 		int bindingDown;
 		int bindingLeft;
@@ -39,11 +69,17 @@ namespace SokuLib
 		int bindingChangeCard;
 		int bindingSpellCard;
 		int bindingPause;
-
-		char unknown2[0x4];
+		int bindingSelect;
+		
 		//  ADDR_KEYMAPOFS          int[8] (32) 0x38
 		KeyInput input;
 		int pause;
+		int select;
+		
+		// copies to/from during replays and netplay:
+		BattleKeys inKeys;
+		BattleKeys outKeys;
+		bool readInKeys;
 	};
 
 	//KEYMGR

--- a/src/Packet.hpp
+++ b/src/Packet.hpp
@@ -132,34 +132,6 @@ namespace SokuLib
 		char name[1];
 	};
 
-	struct CharacterSelectKeys {
-		bool up: 1;
-		bool down: 1;
-		bool left: 1;
-		bool right: 1;
-		bool Z: 1;
-		bool X: 1;
-		bool C: 1;
-		bool A: 1;
-		bool dash: 1;
-		bool Q: 1;
-		unsigned char padding: 6;
-	};
-
-	struct BattleKeys {
-		bool up: 1;
-		bool down: 1;
-		bool left: 1;
-		bool right: 1;
-		bool A: 1;
-		bool B: 1;
-		bool C: 1;
-		bool dash: 1;
-		bool AandB: 1;
-		bool BandC: 1;
-		unsigned char padding: 6;
-	};
-
 	union Inputs {
 		CharacterSelectKeys charSelect;
 		BattleKeys battle;


### PR DESCRIPTION
- Moved `CharacterSelectKeys` and `BattleKeys` to `InputManager.hpp`, because the same struct is used in more places than just packets. `InputManager.hpp` seems the most natural, and it is already included (indirectly) by `Packet.hpp` anyways, so it's the simplest change (and it won't break anyone's builds). This is required for the next change:
- `inKeys` and `outKeys` -- these are read from/to during netplay and replay playback.
- There's another key input handled by `KeymapManager` (!), though as far as I am aware it is unused in the game and is not mappable from the game's UI. Still, it is operated on by numerous functions in the code, as revealed by Ghidra, even though it is ultimately not currently important for anything. I'm using it for another purpose in my upcoming chord-input module. Because the key comes after `pause`/start, I think the name "select" makes sense.